### PR TITLE
Fix/energy points timer

### DIFF
--- a/src/phaser/scene_lvl1.js
+++ b/src/phaser/scene_lvl1.js
@@ -168,7 +168,9 @@ export default class Level1 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator1.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -183,7 +185,9 @@ export default class Level1 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator2.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -198,7 +202,9 @@ export default class Level1 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator3.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -213,7 +219,9 @@ export default class Level1 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator4.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -271,6 +279,7 @@ export default class Level1 extends Phaser.Scene {
     
     gameState.energy = 100
     gameState.particlesCollected = 0
+    gameState.startTime = new Date
     
     const bar = new EnergyBar(this, energyX,energyY,this.fullWidth)
     .withLeftCap(this.add.image(0,0, 'left-capW').setScrollFactor(0))
@@ -287,6 +296,7 @@ export default class Level1 extends Phaser.Scene {
         this.physics.pause()
         points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy * 100
         points.finalParticlesCollected += gameState.particlesCollected * 50
+        points.timeToComplete = Math.floor((new Date - gameState.startTime) / 100)
           this.scene.stop('Level2B');
           this.scene.stop('Level1');
           this.scene.stop('Level2');
@@ -306,6 +316,7 @@ export default class Level1 extends Phaser.Scene {
       this.scene.start('Level2', { 
         backgroundMusic: gameState.backgroundMusic, 
         energy: gameState.energy,
+        startTime: gameState.startTime,
         points
       });
 

--- a/src/phaser/scene_lvl1.js
+++ b/src/phaser/scene_lvl1.js
@@ -285,8 +285,8 @@ export default class Level1 extends Phaser.Scene {
     if (gameState.energy <= 0)
       {
         this.physics.pause()
-        points.energyAtEnd = gameState.energy
-        points.finalParticlesCollected = gameState.particlesCollected * 50
+        points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy * 100
+        points.finalParticlesCollected += gameState.particlesCollected * 50
           this.scene.stop('Level2B');
           this.scene.stop('Level1');
           this.scene.stop('Level2');
@@ -301,7 +301,8 @@ export default class Level1 extends Phaser.Scene {
     //Conditional to load Level 2
     if (gameState.Neo.y > 1375) {
       this.scene.sleep('Level1');
-
+      points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy * 100
+      points.finalParticlesCollected += gameState.particlesCollected * 50
       this.scene.start('Level2', { 
         backgroundMusic: gameState.backgroundMusic, 
         energy: gameState.energy,

--- a/src/phaser/scene_lvl2.js
+++ b/src/phaser/scene_lvl2.js
@@ -306,20 +306,24 @@ export default class Level2 extends Phaser.Scene {
     if (gameState.energy <= 0)
       {
         this.physics.pause()
-        points.energyAtEnd = gameState.energy
-        points.finalParticlesCollected = gameState.particlesCollected * 50
+        points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy
+        points.finalParticlesCollected += gameState.particlesCollected * 50
+        console.log("points", points, gameState.energy)
         // this.add.text(100, 100, "You lose, good day sir/madam").setScrollFactor(0)
           this.scene.stop('Level2B');
           this.scene.stop('Level1');
           this.scene.stop('Level2');
-          this.scene.launch('Highscore') 
+          this.scene.launch('Highscore', {points}) 
       }
   
     if (gameState.currentState === 1) {
       this.scene.sleep("Level2");
+      points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy
+      points.finalParticlesCollected += gameState.particlesCollected * 50
       this.scene.start("Level2B", {
         backgroundMusic: gameState.backgroundMusic,
-        energy: gameState.energy
+        energy: gameState.energy,
+        points
       });
     }
 

--- a/src/phaser/scene_lvl2.js
+++ b/src/phaser/scene_lvl2.js
@@ -15,6 +15,7 @@ export default class Level2 extends Phaser.Scene {
     console.log('init', data);
     gameState.backgroundMusic = data.backgroundMusic;
     gameState.energy = data.energy;
+    gameState.startTime = data.startTime;
     points = data.points;
 
   }
@@ -187,7 +188,9 @@ export default class Level2 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator1.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -202,7 +205,9 @@ export default class Level2 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator2.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -217,7 +222,9 @@ export default class Level2 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator3.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -232,7 +239,9 @@ export default class Level2 extends Phaser.Scene {
           console.log('you got one!')
           energyCreator4.explode()
           gameState.s = true;
-          gameState.energy += 1
+          if (gameState.energy <= 100) {
+            gameState.energy += 1
+          }
           gameState.particlesCollected += 1
           bar.animateToFill(gameState.energy/100)
         }
@@ -308,6 +317,7 @@ export default class Level2 extends Phaser.Scene {
         this.physics.pause()
         points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy
         points.finalParticlesCollected += gameState.particlesCollected * 50
+        points.timeToComplete = Math.floor((new Date - gameState.startTime) / 100)
         console.log("points", points, gameState.energy)
         // this.add.text(100, 100, "You lose, good day sir/madam").setScrollFactor(0)
           this.scene.stop('Level2B');
@@ -323,6 +333,7 @@ export default class Level2 extends Phaser.Scene {
       this.scene.start("Level2B", {
         backgroundMusic: gameState.backgroundMusic,
         energy: gameState.energy,
+        startTime: gameState.startTime,
         points
       });
     }

--- a/src/phaser/scene_lvl2B.js
+++ b/src/phaser/scene_lvl2B.js
@@ -203,12 +203,13 @@ export default class Level2B extends Phaser.Scene {
     }
     
     if (gameState.Neo.x > 3250 || gameState.energy <= 0 || gameState.timeLeft <= 0) {
-      points.energyAtEnd = gameState.energy
-      points.finalParticlesCollected = gameState.particlesCollected * 50
+      points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy * 100
+      points.finalParticlesCollected += gameState.particlesCollected * 50
+      points.scientistTimeRemaining = Math.floor(gameState.timeLeft) * 100
       this.scene.stop('Level2B');
       this.scene.stop('Level1');
       this.scene.stop('Level2');
-      this.scene.launch('Highscore')
+      this.scene.launch('Highscore', {points})
       gameState.Neo.y = 25
     }
   }

--- a/src/phaser/scene_lvl2B.js
+++ b/src/phaser/scene_lvl2B.js
@@ -15,6 +15,7 @@ export default class Level2B extends Phaser.Scene {
     console.log('init', data);
     gameState.backgroundMusic = data.backgroundMusic;
     gameState.energy = data.energy;
+    gameState.startTime = data.startTime;
     points = data.points;
   }
 
@@ -206,6 +207,7 @@ export default class Level2B extends Phaser.Scene {
       points.energyAtEnd = gameState.energy < 0 ? 0 : gameState.energy * 100
       points.finalParticlesCollected += gameState.particlesCollected * 50
       points.scientistTimeRemaining = Math.floor(gameState.timeLeft) * 100
+      points.timeToComplete = Math.floor((new Date - gameState.startTime) / 100)
       this.scene.stop('Level2B');
       this.scene.stop('Level1');
       this.scene.stop('Level2');


### PR DESCRIPTION
I fixed the game not ending right bug, and fixed points transferring through all levels, added points for ending faster escaping the scientist, increased point value for energy total at end of game, and capped healthbar at 100, and timer working and reducing our points by 10/second of game play (one run took me 109 seconds so lost just over 1000 points)